### PR TITLE
Fix: foreground service issue on Android Q and above

### DIFF
--- a/android/src/main/java/io/github/jofr/capacitor/mediasessionplugin/MediaSessionService.java
+++ b/android/src/main/java/io/github/jofr/capacitor/mediasessionplugin/MediaSessionService.java
@@ -109,7 +109,9 @@ public class MediaSessionService extends Service {
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(NOTIFICATION_ID, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+          startForeground(NOTIFICATION_ID, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+        } else {
+          startForeground(NOTIFICATION_ID, notificationBuilder.build());
         }
 
         notificationActions.put("play", new NotificationCompat.Action(


### PR DESCRIPTION
This corrects an error that caused the application to crash because Service.startForeground() was not called after calling Context.startForegroundService() on devices running Android Q or later.

The problem occurred precisely when trying to click on the stop button, as well as when trying to press the different play/pause buttons, and generated a stopped application message. This solution fixes the problem in Android 10 and earlier versions, as it only occurs in these cases.

Oh, and by the way, thank you for the great library you have created. I just felt like contributing with this detail.

![para rama](https://github.com/jofr/capacitor-media-session/assets/127048881/273da874-8528-4be5-961e-fcc8ae1f4bb8)
