### PR TITLE
fix(android): safer urlToBitmap

### DIFF
--- a/android/src/main/java/io/github/jofr/capacitor/mediasessionplugin/MediaSessionPlugin.java
+++ b/android/src/main/java/io/github/jofr/capacitor/mediasessionplugin/MediaSessionPlugin.java
@@ -104,11 +104,16 @@ public class MediaSessionPlugin extends Plugin {
 
         final boolean httpUrl = url.startsWith("http");
         if (httpUrl) {
-            HttpURLConnection connection = (HttpURLConnection) (new URL(url)).openConnection();
-            connection.setDoInput(true);
-            connection.connect();
-            InputStream inputStream = connection.getInputStream();
-            return BitmapFactory.decodeStream(inputStream);
+            try {
+                HttpURLConnection connection = (HttpURLConnection) (new URL(url)).openConnection();
+                connection.setDoInput(true);
+                connection.connect();
+                InputStream inputStream = connection.getInputStream();
+                return BitmapFactory.decodeStream(inputStream);
+            } catch (Exception e) {
+                 Log.e(TAG, "Error fetching artwork", e);
+                return null;
+            }
         }
 
         int base64Index = url.indexOf(";base64,");


### PR DESCRIPTION
if the fetch of the artwork goes wrong (i.e. bad internet connection) the plugin will crash badly.