### PR TITLE
Add permission android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <application>
         <service


### PR DESCRIPTION
If the app targets API level 34 or higher, it must request the appropriate permission type for the kind of work the foreground service will be doing. Each [foreground service type](https://developer.android.com/develop/background-work/services/fg-service-types) has a corresponding permission type:

https://developer.android.com/develop/background-work/services/foreground-services#request-foreground-service-permissions